### PR TITLE
cpu_set should be constant by logic and by other distributions

### DIFF
--- a/libc/include/sched.h
+++ b/libc/include/sched.h
@@ -142,7 +142,7 @@ extern void       __sched_cpufree(cpu_set_t* set);
 
 #define CPU_COUNT_S(setsize, set)  __sched_cpucount((setsize), (set))
 
-extern int __sched_cpucount(size_t setsize, cpu_set_t* set);
+extern int __sched_cpucount(size_t setsize, const cpu_set_t* set);
 
 #endif /* __USE_GNU */
 


### PR DESCRIPTION
As I beleive __sched_cpucount  should come with const-qualifier , because it doesn't change it.
This brakes builds that holds cpu_count mask in a class and trying to use CPU_COUNT macro inside the constant method

class Dummy
{
private:
     cpu_set_t mask;
public:
    int get_cpu_count () const
    {
        return CPU_COUNT(&mask);
    }
};

PS. sorry if I am proposing some stupid thing, but I checked, that it is like that in couple of modern linux distributions.
